### PR TITLE
Update project licenses

### DIFF
--- a/use-cases/node.js/assembler_metal/package.json
+++ b/use-cases/node.js/assembler_metal/package.json
@@ -12,7 +12,7 @@
     "start": "npm run upload && npm run build"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@types/config": "0.0.34",
     "@types/mustache": "^0.8.32",

--- a/use-cases/node.js/run_jcl/package.json
+++ b/use-cases/node.js/run_jcl/package.json
@@ -12,7 +12,7 @@
     "Mainframe"
   ],
   "author": "Zowe CLI Team",
-  "license": "EPL-2.0",
+  "license": "Apache-2.0",
   "dependencies": {
     "@zowe/core-for-zowe-sdk": "^6.24.2",
     "@zowe/imperative": "^4.8.1",

--- a/use-cases/node.js/sonarqube_datasets/package.json
+++ b/use-cases/node.js/sonarqube_datasets/package.json
@@ -14,7 +14,7 @@
     "Mainframe"
   ],
   "author": "Zowe CLI Team",
-  "license": "EPL-2.0",
+  "license": "Apache-2.0",
   "dependencies": {
     "@zowe/core-for-zowe-sdk": "^6.24.2",
     "@zowe/imperative": "^4.8.1",


### PR DESCRIPTION
This PR updates project licenses as recommended by a recent Linux Foundation scan. The scan recommended Apache-2.0 so I changed the other `package.json` files to match. These samples are intended to be shared without the need to contribute the resulting implementation back.

Signed-off-by: MikeBauerCA <Michael.Bauer2@broadcom.com>